### PR TITLE
Add API-based phone lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # verifyphone
-<a href="https://kptaan13.github.io/verifyphone/">VISIT SITE</a> <br>
-I created a simple code for check where this number is valid or not. In this, I used for Montreal, Quebec you can use for your area too. <br>
-I added both javascript and java code for it.
+
+<a href="https://kptaan13.github.io/verifyphone/">VISIT SITE</a><br>
+
+This small demo uses the [apilayer Number Verification API](https://apilayer.com/marketplace/number_verification-api) to look up phone numbers in real time. The page displays the number's country, location, carrier, line type, and whether the API reports it as valid/in use.
+
+## Usage
+
+1. Sign up for a free apilayer account and obtain an API key.
+2. Edit `java.js` and replace `YOUR_API_KEY` with your key.
+3. Open `index.html` in a browser and enter a phone number (including country code).
+
+The included `code.java` file shows a basic Java implementation for validating numbers against specific area codes.

--- a/index.html
+++ b/index.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Phone Number Validation</title>
+  <title>Phone Number Lookup</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="container">
     <form>
-      <h1>Phone Number Validation</h1>
-      <p>Enter number in (1234567892) format:</p>
-      <label for="phone">Enter Phone Number:</label>
+      <h1>Phone Number Lookup</h1>
+      <p>Enter a phone number with country code:</p>
+      <label for="phone">Phone Number:</label>
       <input type="text" id="phone" name="phone" required>
-      <button type="button" onclick="validatePhone()">Validate</button>
-      <div id="alert" class="alert"></div>
+      <button type="button" onclick="lookupPhone()">Lookup</button>
+      <div id="result" class="alert"></div>
     </form>
   </div>
   <script src="java.js"></script>

--- a/java.js
+++ b/java.js
@@ -1,16 +1,40 @@
-function validatePhone() {
-    var phone = document.getElementById("phone").value;
-    if (phone.length == 10 && /^\d+$/.test(phone) &&
-        ((phone.charAt(0) == '5' && phone.charAt(1) == '1' && phone.charAt(2) == '4') ||
-         (phone.charAt(0) == '4' && phone.charAt(1) == '3' && phone.charAt(2) == '8'))) {
-      showAlert("Valid", "alert-success");
-    } else {
-      showAlert("Invalid", "alert-danger");
-    }
+async function lookupPhone() {
+  const phone = document.getElementById("phone").value.trim();
+  const resultEl = document.getElementById("result");
+  resultEl.className = "alert";
+
+  if (!phone) {
+    resultEl.textContent = "Please enter a phone number.";
+    resultEl.classList.add("alert-danger");
+    return;
   }
 
-  function showAlert(message, alertType) {
-    var alert = document.getElementById("alert");
-    alert.innerHTML = message;
-    alert.className = "alert " + alertType;
+  const apiKey = "YOUR_API_KEY"; // Replace with your API key
+  const url = `https://api.apilayer.com/number_verification/validate?number=${encodeURIComponent(phone)}`;
+
+  try {
+    const response = await fetch(url, { headers: { apikey: apiKey } });
+    if (!response.ok) {
+      throw new Error("Lookup request failed");
+    }
+    const data = await response.json();
+    if (data.error) {
+      throw new Error(data.error.info || "Lookup failed");
+    }
+
+    const info = [
+      `Country: ${data.country_name || "N/A"}`,
+      `Location: ${data.location || "N/A"}`,
+      `Carrier: ${data.carrier || "N/A"}`,
+      `Line type: ${data.line_type || "N/A"}`,
+      `In use: ${data.valid ? "Yes" : "No"}`,
+    ].join("<br>");
+
+    resultEl.innerHTML = info;
+    resultEl.classList.add(data.valid ? "alert-success" : "alert-danger");
+  } catch (err) {
+    resultEl.textContent = err.message;
+    resultEl.classList.add("alert-danger");
   }
+}
+


### PR DESCRIPTION
## Summary
- replace simple validation form with real-time phone lookup interface
- integrate apilayer Number Verification API and display country, location, carrier, line type and in-use status
- document how to configure API key and use the demo

## Testing
- `node --check java.js`
- `javac code.java`


------
https://chatgpt.com/codex/tasks/task_e_68aa6e10a63c8320b29d443183a534e2