### PR TITLE
Handle whitespace in phone number validation

### DIFF
--- a/code.java
+++ b/code.java
@@ -4,21 +4,22 @@ public class code {
 	public static void main(String[] args) {
 		Scanner input = new Scanner(System.in);
 		System.out.println("Enter number in (1234567892) format : ");
-		String num = input.nextLine();
-		if(valPhone(num)) {
+                String num = input.nextLine().trim();
+                if(valPhone(num)) {
 		System.out.println("Valid");
 		}
 		else {
 		System.out.println("Invalid");
 		}
 		}
-		public static boolean valPhone(String num) {
-		return  (num.length()==10 && num.matches("[0-9]+"))
-		&& ((num.charAt(0)== '5'
-		&& num.charAt(1)== '1' 
-		&& num.charAt(2)== '4')
-		|| (num.charAt(0)== '4'
-		&& num.charAt(1)== '3'
-		&& num.charAt(2)== '8'));
-	}
+                public static boolean valPhone(String num) {
+                num = num.trim();
+                return  (num.length()==10 && num.matches("[0-9]+"))
+                && ((num.charAt(0)== '5'
+                && num.charAt(1)== '1'
+                && num.charAt(2)== '4')
+                || (num.charAt(0)== '4'
+                && num.charAt(1)== '3'
+                && num.charAt(2)== '8'));
+        }
 }

--- a/java.js
+++ b/java.js
@@ -1,5 +1,5 @@
 function validatePhone() {
-    var phone = document.getElementById("phone").value;
+    var phone = document.getElementById("phone").value.trim();
     if (phone.length == 10 && /^\d+$/.test(phone) &&
         ((phone.charAt(0) == '5' && phone.charAt(1) == '1' && phone.charAt(2) == '4') ||
          (phone.charAt(0) == '4' && phone.charAt(1) == '3' && phone.charAt(2) == '8'))) {


### PR DESCRIPTION
## Summary
- trim user input before validating phone numbers in Java and JavaScript implementations
- add a secondary trim inside Java validator for robustness

## Testing
- `javac -d . code.java`
- `java verifyphone.code <<'EOF'
 5141234567 
EOF`
- `node -e "function validate(phone){phone=phone.trim();return phone.length==10 && /^\d+$/.test(phone)&&((phone.charAt(0)=='5'&&phone.charAt(1)=='1'&&phone.charAt(2)=='4')||(phone.charAt(0)=='4'&&phone.charAt(1)=='3'&&phone.charAt(2)=='8'));} console.log(validate(' 5141234567 ')); console.log(validate('5141234567'))"`


------
https://chatgpt.com/codex/tasks/task_e_68aa6dd4b9908320a4529117624e9c97